### PR TITLE
Update URL

### DIFF
--- a/metadata/pythonAlgo.json
+++ b/metadata/pythonAlgo.json
@@ -7,7 +7,7 @@
     "license": "CC-BY",
     "files": [
       {
-        "url": "https://raw.githubusercontent.com/oceanprotocol/cdt-algorithms/main/python/linecounter/line_counter.py",
+        "url": "https://raw.githubusercontent.com/oceanprotocol/c2d-examples/main/python/linecounter/line_counter.py",
         "contentType": "text/js",
         "encoding": "UTF-8"
       }


### PR DESCRIPTION
Fixes #4

Changes proposed in this PR:

- Update URL to point to the newly renamed c2d-examples repo: https://github.com/oceanprotocol/c2d-examples