### PR TITLE
Bump ocean.js lib 3.1.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@oceanprotocol/contracts": "^1.1.14",
-        "@oceanprotocol/lib": "^3.1.0",
+        "@oceanprotocol/lib": "^3.1.1",
         "cross-fetch": "^3.1.5",
         "crypto-js": "^4.1.1",
         "decimal.js": "^10.4.1",
@@ -748,9 +748,9 @@
       "integrity": "sha512-PJih7C6LHaWHHj1qgxZsSkEqKphhJrL3G7WuMOxl4N1daDrF6sooDDU+9dZkcHSVPc7cMjkFqLc5fP58NSAobw=="
     },
     "node_modules/@oceanprotocol/lib": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@oceanprotocol/lib/-/lib-3.1.0.tgz",
-      "integrity": "sha512-BibntT9JOOeXDVwxLE2fj2ktB/n4BJ7bIf3S/hQYsVb/f1NQvSE+VT6h5rShHrQzq0zrLZkm1l4GrC46+2gthA==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@oceanprotocol/lib/-/lib-3.1.1.tgz",
+      "integrity": "sha512-OCinF20Bj4xPXbZZXdq4oXlmgzGS4NuIdVVCawb/ouKF0JEt8LLOB+/a/DWiqzL5UQO060/T3zizOxrJyh19Qw==",
       "dependencies": {
         "@oceanprotocol/contracts": "^1.1.14",
         "cross-fetch": "^3.1.5",
@@ -4818,9 +4818,9 @@
       "integrity": "sha512-PJih7C6LHaWHHj1qgxZsSkEqKphhJrL3G7WuMOxl4N1daDrF6sooDDU+9dZkcHSVPc7cMjkFqLc5fP58NSAobw=="
     },
     "@oceanprotocol/lib": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@oceanprotocol/lib/-/lib-3.1.0.tgz",
-      "integrity": "sha512-BibntT9JOOeXDVwxLE2fj2ktB/n4BJ7bIf3S/hQYsVb/f1NQvSE+VT6h5rShHrQzq0zrLZkm1l4GrC46+2gthA==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@oceanprotocol/lib/-/lib-3.1.1.tgz",
+      "integrity": "sha512-OCinF20Bj4xPXbZZXdq4oXlmgzGS4NuIdVVCawb/ouKF0JEt8LLOB+/a/DWiqzL5UQO060/T3zizOxrJyh19Qw==",
       "requires": {
         "@oceanprotocol/contracts": "^1.1.14",
         "cross-fetch": "^3.1.5",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "homepage": "https://github.com/oceanprotocol/ocean.js-cli#readme",
   "dependencies": {
     "@oceanprotocol/contracts": "^1.1.14",
-    "@oceanprotocol/lib": "^3.1.0",
+    "@oceanprotocol/lib": "^3.1.1",
     "cross-fetch": "^3.1.5",
     "crypto-js": "^4.1.1",
     "decimal.js": "^10.4.1",


### PR DESCRIPTION
Fixes # .

Changes proposed in this PR:

- bump oceanjs to 3.1.1 version
